### PR TITLE
Support resizable bar detection using Level Zero

### DIFF
--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -133,6 +133,7 @@ namespace XI
 		{1275, "Lunar Lake", "LNL_", 0x5010004}, // TODO: Remove one of these when no longer needed
 		// Devices with no "Intel Device Information" value have negative values
 		{0x80000000, "NPU2.7", "mtl_w" },
+		{0x80000000, "NPU2.7", "NPU2_7" },
 		{0x80000002, "NPU4", "NPU4" }
 	};
 	static const int S_numGenNames = sizeof(S_GenNameMap)/sizeof(GenName);

--- a/LibXPUInfo_L0.cpp
+++ b/LibXPUInfo_L0.cpp
@@ -125,27 +125,44 @@ void Device::initL0Device(ze_device_handle_t inL0Device, const ze_device_propert
 			}
 		}
 
-		zes_pci_bar_properties_1_2_t pci_props_1_2{ ZES_STRUCTURE_TYPE_PCI_BAR_PROPERTIES_1_2, };
-		zes_pci_properties_t pci_props{ ZES_STRUCTURE_TYPE_PCI_PROPERTIES, };
-		pci_props.pNext = &pci_props_1_2;
-		ze_result_t zRet = zesDevicePciGetProperties(m_L0Device, &pci_props);
+		ze_result_t zRet;
+
+		uint32_t pciBarCount = 0;
+		zRet = zesDevicePciGetBars(m_L0Device, &pciBarCount, nullptr);
+		// zesDeviceGetProperties?
 		if (ZE_RESULT_SUCCESS == zRet)
 		{
-			if (!m_props.PCIReBAR.valid)
+			std::vector<zes_pci_bar_properties_t> barPropsVec(pciBarCount);
+			std::vector <zes_pci_bar_properties_1_2_t> pci_bar_props_1_2(pciBarCount);
+			for (uint32_t i = 0; i < pciBarCount; ++i)
 			{
-				m_props.PCIReBAR.valid = pci_props_1_2.resizableBarSupported ||
-					(!pci_props_1_2.resizableBarSupported && !pci_props_1_2.resizableBarEnabled);
-				m_props.PCIReBAR.supported = pci_props_1_2.resizableBarSupported;
-				m_props.PCIReBAR.enabled = pci_props_1_2.resizableBarEnabled;
+				barPropsVec[i].stype = ZES_STRUCTURE_TYPE_PCI_BAR_PROPERTIES;
+				barPropsVec[i].pNext = &(pci_bar_props_1_2[i]);
+				pci_bar_props_1_2[i].stype = ZES_STRUCTURE_TYPE_PCI_BAR_PROPERTIES_1_2;
+			}
+
+			zRet = zesDevicePciGetBars(m_L0Device, &pciBarCount, (zes_pci_bar_properties_t*)barPropsVec.data());
+			if (ZE_RESULT_SUCCESS == zRet)
+			{
+				for (uint32_t i = 0; i < pciBarCount; ++i)
+				{
+					if (ZES_PCI_BAR_TYPE_MMIO == barPropsVec[i].type)
+					{
+						if (!m_props.PCIReBAR.valid)
+						{
+							m_props.PCIReBAR.valid = pci_bar_props_1_2[i].resizableBarSupported ||
+								(!pci_bar_props_1_2[i].resizableBarSupported && !pci_bar_props_1_2[i].resizableBarEnabled);
+							m_props.PCIReBAR.supported = pci_bar_props_1_2[i].resizableBarSupported;
+							m_props.PCIReBAR.enabled = pci_bar_props_1_2[i].resizableBarEnabled;
+						}
+						break;
+					}
+				}
 			}
 		}
-		else
-		{
-			// Try again without zes_pci_bar_properties_1_2_t
-			pci_props.pNext = nullptr;
-			zRet = zesDevicePciGetProperties(m_L0Device, &pci_props);
-		}
 
+		zes_pci_properties_t pci_props{ ZES_STRUCTURE_TYPE_PCI_PROPERTIES, };
+		zRet = zesDevicePciGetProperties(m_L0Device, &pci_props);
 		if (ZE_RESULT_SUCCESS == zRet)
 		{
 			DebugStreamW dStr(XPUINFO_L0_VERBOSE);
@@ -497,6 +514,9 @@ void XPUInfo::initL0()
 	for (auto l0enum : L0Drivers)
 	{
 		ze_result_t zRes;
+		ze_api_version_t zeVersion{};
+		zRes = zeDriverGetApiVersion(l0enum.driver, &zeVersion);
+
 		uint32_t numExts = 0;
 		zRes = zeDriverGetExtensionProperties(l0enum.driver, &numExts, nullptr);
 		L0_Extensions driverExts(numExts);

--- a/LibXPUInfo_L0.cpp
+++ b/LibXPUInfo_L0.cpp
@@ -558,7 +558,6 @@ void XPUInfo::initL0()
 
 			if (ZE_RESULT_SUCCESS == zRes)
 			{
-				// See https://hsdes.intel.com/appstore/article/#/14018468731 - [DG2][ADL] Level Zero device_luid_ext_properties_t always giving NULL LUID
 				UI64 l0luid = LuidToUI64(&device_luid_ext_properties.luid.id[0]);
 				bool bFound = false;
 				if (pLuidExt && l0luid)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ LibXPUInfo coalesces multiple APIs to provide multi-vendor, cross-platform devic
 * Windows
   * If you want to use nVidia NVML and accept [NVML license](https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/LICENSE.txt), run external\getNVMLDep.bat
     * If you do not want to use NVML, remove XPUINFO_USE_NVML from preprocessor arguments for LibXPUInfo.vcxproj
-  * If you want to use OpenCL and accept related Apache-2.0 licenses, run external/buildExternalDeps_OCL.bat
-  * If you want to use Level Zero and accept related MIT license, run external/buildExternalDeps_L0.bat
+  * If you want to use OpenCL and accept related Apache-2.0 licenses, run **external/buildExternalDeps_OCL.bat**
+  * If you want to use Level Zero and accept related MIT license, run **external/buildExternalDeps_L0.bat**
     * See above note regarding Spectre-mitigated libs
   * Open LibXPUInfo.sln and build
-    * Note: Modify XPUINFO_USE_* preprocessor flags as desired 
+    * Note: Modify XPUINFO_USE_* preprocessor flags as desired
+    * **Note:** If you pull changes that update the Level Zero or OpenCL submodules, run the correspondig buildExternalDeps_*.bat again before building LibXPUInfo.
  * MacOS/Linux - Not currently supported. No build config files provided. Use at your own risk - information provided may be incorrect.


### PR DESCRIPTION
Resizable bar detection was handled by IGCL, but since IGCL calls zeInit(0) which blocks all NPU detection, we should not use it.  This change completes the porting of features from IGCL to Level Zero.  (IGCL support may be removed in the future.)
- Update L0 loader to 1.18.3
- Detect resizable bar supported/enabled using L0
- [Misc] Update Meteor Lake NPU inf name