### PR TITLE
Move list of tracked runtimes outside of LibXPUInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ x64
 *.bak
 BuildExternalDeps/NVML
 BuildExternalDeps/NVML.zip
+*.vcxproj.user

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -861,7 +861,7 @@ UI64 DeviceProperties::getVideoMemorySize() const
 		dxgiDesc.DedicatedVideoMemory;
 }
 
-XPUInfo::XPUInfo(APIType initMask, size_t clientClassSize) : m_UsedAPIs(API_TYPE_UNKNOWN)
+XPUInfo::XPUInfo(APIType initMask, const RuntimeNames& runtimeNamesToTrack, size_t clientClassSize) : m_UsedAPIs(API_TYPE_UNKNOWN)
 {
 	// Verify class size matches between internal lib and clients
 	const size_t libClassSize = sizeof(XPUInfo);
@@ -1027,7 +1027,7 @@ XPUInfo::XPUInfo(APIType initMask, size_t clientClassSize) : m_UsedAPIs(API_TYPE
 #ifdef XPUINFO_USE_RUNTIMEVERSIONINFO
 	if (!(initMask & API_TYPE_DESERIALIZED))
 	{
-		getRuntimeVersions();
+		getRuntimeVersions(runtimeNamesToTrack);
 	}
 #endif
 
@@ -1049,18 +1049,11 @@ String RuntimeVersion::getAsString() const
 	return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(build);
 }
 
-void XPUInfo::getRuntimeVersions()
+void XPUInfo::getRuntimeVersions(const RuntimeNames& runtimeNames)
 {
 #ifdef _WIN32
 	RuntimeVersion ver;
-	static const std::vector<const char*> runtimes = {
-		"Microsoft.AI.MachineLearning.dll", "DirectML.dll", "onnxruntime.dll", "OpenVino.dll",
-		"onnxruntime_providers_shared.dll", "onnxruntime_providers_openvino.dll",
-		"tbb12.dll", "tbb.dll", "tbb12_debug.dll", "tbb_debug.dll",
-		"libmmd.dll", "libmmdd.dll"
-		//, "kernel32.dll" // Indicates Windows version
-	};
-	for (const auto& file : runtimes)
+	for (const auto& file : runtimeNames)
 	{
 		if (Win::GetVersionFromFile(file, ver))
 		{

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -75,6 +75,11 @@ namespace XI {
 }
 #define ENABLE_PER_LOGICAL_CPUID_ISA_DETECTION 0
 #define XPUINFO_REQUIRE(x) if (!(x)) XI::getErrorHandlerFunc()(#x, __FILE__, __LINE__)
+#define XPUINFO_REQUIRE_CONSTEXPR_MSG(x, msg) if constexpr (!(x)) { \
+            std::ostringstream ostr; \
+            ostr << msg; \
+            XI::getErrorHandlerFunc()(ostr.str(), __FILE__, __LINE__); \
+        }
 #define XPUINFO_REQUIRE_MSG(x, msg) if (!(x)) { \
             std::ostringstream ostr; \
             ostr << msg; \

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -899,7 +899,7 @@ namespace XI
 
     class XPUInfo;
     typedef std::shared_ptr<XPUInfo> XPUInfoPtr;
-    typedef std::vector<const char*> RuntimeNames; // Minimum lifetime needs to be at least during XPUInfo constructor
+    typedef std::vector<std::string> RuntimeNames;
 
     class XPUINFO_EXPORT XPUInfo
     {

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -899,13 +899,14 @@ namespace XI
 
     class XPUInfo;
     typedef std::shared_ptr<XPUInfo> XPUInfoPtr;
+    typedef std::vector<const char*> RuntimeNames; // Minimum lifetime needs to be at least during XPUInfo constructor
 
     class XPUINFO_EXPORT XPUInfo
     {
     public:
         // Constructor compares class size of client to that of lib to help verify that 
         // preprocessor arguments are in agreement between different projects.
-        XPUInfo(APIType initMask, size_t classSize = sizeof(XPUInfo));
+        XPUInfo(APIType initMask, const RuntimeNames& runtimeNamesToTrack = RuntimeNames(), size_t classSize = sizeof(XPUInfo));
         ~XPUInfo();
         size_t deviceCount() const { return m_Devices.size(); }
         template <APIType APITYPE>
@@ -979,7 +980,7 @@ namespace XI
         std::shared_ptr<DeviceCPU> m_pCPU;
 
 #ifdef XPUINFO_USE_RUNTIMEVERSIONINFO
-        void getRuntimeVersions();
+        void getRuntimeVersions(const RuntimeNames& runtimeNames);
         RuntimeVersionInfoMap m_RuntimeVersions;
 #endif
     };

--- a/LibXPUInfo.vcxproj.user
+++ b/LibXPUInfo.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -163,8 +163,14 @@ int printXPUInfo(int argc, char* argv[])
 #endif
     }
 
+    static const XI::XPUInfo::RuntimeNames runtimes = {
+        "Microsoft.AI.MachineLearning.dll", "DirectML.dll", "onnxruntime.dll", "OpenVino.dll",
+        "onnxruntime_providers_shared.dll", "onnxruntime_providers_openvino.dll",
+    };
+
     try
     {
+
         if (!testIndividual)
         {
             XI::Timer timer;
@@ -179,7 +185,7 @@ int printXPUInfo(int argc, char* argv[])
             apis |= additionalAPIs;
             timer.Start();
             std::cout << "Initializing XPUInfo with APIType = " << apis << "...\n";
-            XI::XPUInfo xi(apis);
+            XI::XPUInfo xi(apis, runtimes);
             std::cout << xi << std::endl;
             timer.Stop();
             std::cout << "XPUInfo Time: " << timer.GetElapsedSecs() << " seconds\n";
@@ -206,7 +212,7 @@ int printXPUInfo(int argc, char* argv[])
                 std::cout << "Initializing XPUInfo with APIType = " << api << "...\n";
                 XI::Timer timer;
                 timer.Start();
-                XI::XPUInfo xi(api);
+                XI::XPUInfo xi(api, runtimes);
                 std::cout << xi << std::endl;
                 timer.Stop();
                 std::cout << "XPUInfo Time: " << timer.GetElapsedSecs() << " seconds\n";

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -163,7 +163,7 @@ int printXPUInfo(int argc, char* argv[])
 #endif
     }
 
-    static const XI::XPUInfo::RuntimeNames runtimes = {
+    static const XI::RuntimeNames runtimes = {
         "Microsoft.AI.MachineLearning.dll", "DirectML.dll", "onnxruntime.dll", "OpenVino.dll",
         "onnxruntime_providers_shared.dll", "onnxruntime_providers_openvino.dll",
     };

--- a/TestLibXPUInfo/TestLibXPUInfo.vcxproj.user
+++ b/TestLibXPUInfo/TestLibXPUInfo.vcxproj.user
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-verify_json</LocalDebuggerCommandArguments>
-    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-  </PropertyGroup>
-</Project>

--- a/TestXPUInfoIPC/TestXPUInfoIPC.cpp
+++ b/TestXPUInfoIPC/TestXPUInfoIPC.cpp
@@ -332,14 +332,14 @@ int main(int argc, char* argv[])
                 }
         }
 
-        XPUINFO_REQUIRE_MSG(TESTXPUINFOIPC_SUPPORT_PIPE || TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
+        XPUINFO_REQUIRE_CONSTEXPR_MSG(TESTXPUINFOIPC_SUPPORT_PIPE || TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
             "Must build with TESTXPUINFOIPC_SUPPORT_PIPE or TESTXPUINFOIPC_SUPPORT_SHAREDMEM");
 #if TESTXPUINFOIPC_SUPPORT_PIPE || TESTXPUINFOIPC_SUPPORT_SHAREDMEM
         if (isServer)
         {
             if (usePipe)
             {
-                XPUINFO_REQUIRE_MSG(TESTXPUINFOIPC_SUPPORT_PIPE,
+                XPUINFO_REQUIRE_CONSTEXPR_MSG(TESTXPUINFOIPC_SUPPORT_PIPE,
                     "Must build with TESTXPUINFOIPC_SUPPORT_PIPE");
 #if TESTXPUINFOIPC_SUPPORT_PIPE
                 procRetVal = XPUInfo_IPC_Server_Pipe();
@@ -347,7 +347,7 @@ int main(int argc, char* argv[])
             }
             else
             {
-                XPUINFO_REQUIRE_MSG(TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
+                XPUINFO_REQUIRE_CONSTEXPR_MSG(TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
                     "Must build with TESTXPUINFOIPC_SUPPORT_SHAREDMEM");
 #if TESTXPUINFOIPC_SUPPORT_SHAREDMEM
                 procRetVal = XPUInfo_IPC_Server();
@@ -371,7 +371,7 @@ int main(int argc, char* argv[])
                 XI::Win::ProcessInformation pi;
                 if (!usePipe)
                 {
-                    XPUINFO_REQUIRE_MSG(TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
+                    XPUINFO_REQUIRE_CONSTEXPR_MSG(TESTXPUINFOIPC_SUPPORT_SHAREDMEM,
                         "Must build with TESTXPUINFOIPC_SUPPORT_SHAREDMEM");
                     args += " -sharedmem";
 #if TESTXPUINFOIPC_SUPPORT_SHAREDMEM
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
                 }
                 else
                 {
-                    XPUINFO_REQUIRE_MSG(TESTXPUINFOIPC_SUPPORT_PIPE,
+                    XPUINFO_REQUIRE_CONSTEXPR_MSG(TESTXPUINFOIPC_SUPPORT_PIPE,
                         "Must build with TESTXPUINFOIPC_SUPPORT_PIPE");
 #if TESTXPUINFOIPC_SUPPORT_PIPE
                     procRetVal = XPUInfoIPC_Client_Pipe(args.c_str(), pi);

--- a/TestXPUInfoIPC/TestXPUInfoIPC.vcxproj
+++ b/TestXPUInfoIPC/TestXPUInfoIPC.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{7c4fe0e5-0fe3-42c7-9147-2976b55d022c}</ProjectGuid>
     <RootNamespace>TestXPUInfoIPC</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>XPUInfoIPC</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/TestXPUInfoIPC/TestXPUInfoIPC.vcxproj.user
+++ b/TestXPUInfoIPC/TestXPUInfoIPC.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/TestXPUInfoIPC/TestXPUInfoIPC_Shared/TestXPUInfoIPC_Shared.vcxproj.user
+++ b/TestXPUInfoIPC/TestXPUInfoIPC_Shared/TestXPUInfoIPC_Shared.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>


### PR DESCRIPTION
Allow clients to pass in the list to XPUInfo constructor.
Also:
- Fix build due to warning-as-error on constant conditional.
- Rename binary TestXPUInfoIPC to XPUInfoIPC to reflect that it is not just a test app, but a helper app that clients can use to initialize XPUInfo out-of-process.