### PR TITLE
Add IntelGfxFamily/Name to XI::Device interface 

### DIFF
--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -112,22 +112,6 @@ namespace XI
 		ipvUnion ipvu;
 	};
 
-	enum class IntelGfxFamily : UI32
-	{
-        iUnknown,
-        iGen9_Generic,
-        iGen11_Generic,
-        iGen12LP_Generic,
-        iGen12HP_DG2,
-        iXe_S, // MTL-U, ARL-S, ARL-U
-        iXe_L_MeteorLakeH,
-        iXe_L_ArrowLakeH,
-        iXe2_Generic,
-        iXe2_LunarLake,
-        iXe2_BattleMage,
-        iXe3_Generic
-	};
-
 #define MAKE_FAMILY_NAME_PAIR(x) {IntelGfxFamily::i##x, #x}
 	static const std::unordered_map<IntelGfxFamily, std::string> S_IntelGfxFamilyNameMap {
 		MAKE_FAMILY_NAME_PAIR(Gen9_Generic),
@@ -166,6 +150,25 @@ namespace XI
 		default: outFamily = IntelGfxFamily::iUnknown; break;
 		}
 		return outFamily;
+	}
+
+	std::optional<IntelGfxFamilyNamePair> Device::getIntelGfxFamilyName() const
+	{
+		if (IsVendor(kVendorId_Intel) && getType()==DEVICE_TYPE_GPU)
+		{
+			ipvUnion ipvu;
+			ipvu.ipVersion = m_props.DeviceIPVersion;
+			if (ipvu.ipVersion)
+			{
+				auto ipFamily = getIntelGfxFamily(ipvu.ipv);
+				auto ipfIter = S_IntelGfxFamilyNameMap.find(ipFamily);
+				if (ipfIter != S_IntelGfxFamilyNameMap.end())
+				{
+					return *ipfIter;
+				}
+			}
+		}
+		return std::nullopt;
 	}
 
 	/* This table is purposefully internal to LibXPUInfo. 
@@ -685,7 +688,8 @@ void XPUInfo::initDXGI(APIType initMask)
 					if (!(m_UsedAPIs & API_TYPE_DXGI))
 						m_UsedAPIs = m_UsedAPIs | API_TYPE_DXGI;
 
-					if (initMask & API_TYPE_DX11_INTEL_PERF_COUNTER)
+					if ((initMask & API_TYPE_DX11_INTEL_PERF_COUNTER) && 
+						newDevice->IsVendor(kVendorId_Intel)) // Early-out for non-Intel devices
 					{
 						newIt.first->second->initDXIntelPerfCounter(adapter.Get());
 
@@ -1452,20 +1456,10 @@ std::ostream& operator<<(std::ostream& ostr, const Device& xiDev)
 			SaveRestoreIOSFlags sr(ostr);
 			ostr << "\tIP Version: 0x" << std::hex << std::setw(8) << std::right << std::setfill('0') << devProps.DeviceIPVersion;
 		}
-		if (xiDev.IsVendor(kVendorId_Intel))
+		auto IntelFamilyName = xiDev.getIntelGfxFamilyName();
+		if (IntelFamilyName.has_value())
 		{
-			ipvUnion ipvu;
-			ipvu.ipVersion = xiDev.getProperties().DeviceIPVersion;
-			if (ipvu.ipVersion)
-			{
-				//ostr << ", Architecture: " << ipvu.ipv.architecture << ", Release: " << ipvu.ipv.release << ", Revision: " << ipvu.ipv.revision;
-				auto ipFamily = getIntelGfxFamily(ipvu.ipv);
-				auto ipfIter = S_IntelGfxFamilyNameMap.find(ipFamily);
-				if (ipfIter != S_IntelGfxFamilyNameMap.end())
-				{
-					ostr << ", " << ipfIter->second;
-				}
-			}
+			ostr << ", " << IntelFamilyName->second;
 		}
 		ostr << std::endl;
 	}

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -689,8 +689,11 @@ void XPUInfo::initDXGI(APIType initMask)
 					{
 						newIt.first->second->initDXIntelPerfCounter(adapter.Get());
 
-						if (!(m_UsedAPIs & API_TYPE_DX11_INTEL_PERF_COUNTER))
+						if (!(m_UsedAPIs & API_TYPE_DX11_INTEL_PERF_COUNTER)
+							&& (newIt.first->second->getCurrentAPIs() & API_TYPE_DX11_INTEL_PERF_COUNTER))
+						{
 							m_UsedAPIs = m_UsedAPIs | API_TYPE_DX11_INTEL_PERF_COUNTER;
+						}
 					}
 				}
             }

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -362,6 +362,23 @@ namespace XI
     };
     typedef std::shared_ptr<DriverInfo> DriverInfoPtr;
 
+    enum class IntelGfxFamily : UI32
+    {
+        iUnknown,
+        iGen9_Generic,
+        iGen11_Generic,
+        iGen12LP_Generic,
+        iGen12HP_DG2,
+        iXe_S, // MTL-U, ARL-S, ARL-U
+        iXe_L_MeteorLakeH,
+        iXe_L_ArrowLakeH,
+        iXe2_Generic,
+        iXe2_LunarLake,
+        iXe2_BattleMage,
+        iXe3_Generic
+    };
+    typedef std::pair<IntelGfxFamily, std::string> IntelGfxFamilyNamePair;
+
     const UINT kVendorId_Intel = 0x8086;
     const UINT kVendorId_nVidia = 0x10de;
 
@@ -431,6 +448,7 @@ namespace XI
         UI64 getTotalVideoMemorySize() const { return dxgiDesc.DedicatedVideoMemory + dxgiDesc.SharedSystemMemory; }
         UI64 getVideoMemorySize() const;
         bool operator==(const DeviceProperties& props) const;
+        bool IsVendor(const UINT inVendorId) const { return dxgiDesc.VendorId == inVendorId; }
     };
 
     class XPUINFO_EXPORT DeviceBase
@@ -504,7 +522,7 @@ namespace XI
         IDXCoreAdapter* const getHandle_DXCore() const { return m_pDXCoreAdapter.get(); }
 #endif
 
-        bool IsVendor(const UINT inVendorId) const { return m_props.dxgiDesc.VendorId == inVendorId; }
+        bool IsVendor(const UINT inVendorId) const { return m_props.IsVendor(inVendorId); }
 
         DXCoreAdapterMemoryBudget getMemUsage() const;
 
@@ -513,6 +531,7 @@ namespace XI
         static DevicePtr deserialize(const rapidjson::Value& val);
 #endif
         bool operator==(const Device& dev) const;
+        std::optional<IntelGfxFamilyNamePair> getIntelGfxFamilyName() const;
 
     protected:
         APIType validAPIs = API_TYPE_UNKNOWN;


### PR DESCRIPTION
This exposes another method besides API_TYPE_DX11_INTEL_PERF_COUNTER that can be used to classify Intel GPUs.

Also, (bugfix) check success for init of API_TYPE_DX11_INTEL_PERF_COUNTER before setting m_UsedAPIs.
