### PR TITLE
Add generic NPU detection

### DIFF
--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -1024,6 +1024,8 @@ namespace XI
 #ifdef _WIN32
         std::shared_ptr<SetupDeviceInfo> m_pSetupInfo;
         winrt::com_ptr<IDXCoreAdapterFactory> m_spFactoryDXCore;
+
+        // These lists are class objects for use with ScopedRegisterNotification
         winrt::com_ptr<IDXCoreAdapterList> m_spAdapterList;
         winrt::com_ptr<IDXCoreAdapterList> m_spAdapterList2;
         winrt::com_ptr<IDXCoreAdapterList> m_spAdapterListNPU;

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -1026,6 +1026,7 @@ namespace XI
         winrt::com_ptr<IDXCoreAdapterFactory> m_spFactoryDXCore;
         winrt::com_ptr<IDXCoreAdapterList> m_spAdapterList;
         winrt::com_ptr<IDXCoreAdapterList> m_spAdapterList2;
+        winrt::com_ptr<IDXCoreAdapterList> m_spAdapterListNPU;
 #endif
         std::shared_ptr<DeviceCPU> m_pCPU;
 


### PR DESCRIPTION
Using DXCORE_HARDWARE_TYPE_ATTRIBUTE_NPU also for NPUs that do not support DX12 metacommands.
Also reduce binary size by using `if constexpr (bPrintInfo)`.