### PR TITLE
Add CUDA Compute Capability

### DIFF
--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -1482,7 +1482,7 @@ std::ostream& operator<<(std::ostream& ostr, const Device& xiDev)
 	if (xiDev.IsVendor(kVendorId_nVidia))
 	{
 		auto ccc = devProps.VendorSpecific.nVidia.getCudaComputeCapability();
-		if (ccc)
+		if (ccc > 0)
 		{
 			ostr << "\tCUDA Compute Capability: " << ccc << std::endl;
 		}

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -1550,15 +1550,15 @@ void DeviceCPU::printInfo(std::ostream& ostr, const SystemInfo* pSysInfo) const
 				numCores += p.NumberOfCores;
 				numLP += p.NumberOfLogicalProcessors;
 			}
-			if (numEnabledCores != m_pProcInfo->numPhysicalCores)
+			if (numEnabledCores && (numEnabledCores != m_pProcInfo->numPhysicalCores))
 			{
 				ostr << "\tCores Enabled: " << numEnabledCores << std::endl;
 			}
-			if (numCores != m_pProcInfo->numPhysicalCores)
+			if (numCores && (numCores != m_pProcInfo->numPhysicalCores))
 			{
 				ostr << "\tSystem Cores: " << numCores << std::endl;
 			}
-			if (numLP != m_pProcInfo->numLogicalCores)
+			if (numLP && (numLP != m_pProcInfo->numLogicalCores))
 			{
 				ostr << "\tSystem Logical: " << numLP << std::endl;
 			}

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -228,6 +228,8 @@ namespace XI
 		{7, "Ampere"},
 		{8, "Ada"},
 		{9, "Hopper"},
+		{10, "Blackwell"},
+		{11, "Orin"},
 	};
 
 	std::ostream& operator<<(std::ostream& s, APIType t)

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -1477,6 +1477,14 @@ std::ostream& operator<<(std::ostream& ostr, const Device& xiDev)
 			ostr << "DPAS ";
 		ostr << std::endl;
 	}
+	if (xiDev.IsVendor(kVendorId_nVidia))
+	{
+		auto ccc = devProps.VendorSpecific.nVidia.getCudaComputeCapability();
+		if (ccc)
+		{
+			ostr << "\tCUDA Compute Capability: " << ccc << std::endl;
+		}
+	}
 	if (devProps.NumComputeUnits != -1)
 	{
 		ostr << "\tCompute Units: " << devProps.NumComputeUnits;

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -443,6 +443,19 @@ namespace XI
             UI32 IntelFeatureFlagsUI32;
         } VendorFlags = {};         // From OpenCL
 
+        union
+        {
+            struct
+            {
+                int getCudaComputeCapability() const
+                {
+                    return cudaComputeCapability_Major * 10 + cudaComputeCapability_Minor;
+                }
+                int cudaComputeCapability_Major;
+                int cudaComputeCapability_Minor;
+            } nVidia;
+        } VendorSpecific;
+
         I8 IsHighPerformance = -1;  // Only 1 Device will be set.  From DXCore.
         I8 IsMinimumPower = -1;     // Only 1 Device will be set.  From DXCore.
         I8 IsDetachable = -1;       // From DXCore

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -127,9 +127,7 @@ Given a GPU entry from this list, it will tell us <hardware, framework> to run t
     Framework is OpenVINO, OpenVINO-CPU, ORT-CPU, TensorRT.
 */
 
-// TODO: For nVidia GPU info, find path to driver files, run nvidia-smi - see "nvidia-smi --help-query-gpu"
-// i.e. nvidia-smi --query-gpu=timestamp,name,pci.bus_id,driver_version,pstate,pcie.link.gen.max,pcie.link.gen.current,pcie.link.width.current,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory.used,power.default_limit,power.max_limit,enforced.power.limit,power.limit,clocks.max.gr --format=csv
-// For direct-access, see NVML at https://developer.nvidia.com/nvidia-management-library-nvml
+// NVML docs at https://developer.nvidia.com/nvidia-management-library-nvml
 // TODO: For AMD, see https://gpuopen.com/gpuperfapi/, see ADLX
 // 
 
@@ -447,6 +445,7 @@ namespace XI
         {
             struct
             {
+                // <0 is unknown, 0 is invalid
                 int getCudaComputeCapability() const
                 {
                     return cudaComputeCapability_Major * 10 + cudaComputeCapability_Minor;

--- a/LibXPUInfo_JSON.cpp
+++ b/LibXPUInfo_JSON.cpp
@@ -217,7 +217,13 @@ DevicePtr Device::deserialize(const rapidjson::Value& val)
         newDev->m_props.PCIDeviceGen = safeGetI32(val, "PCIDeviceGen").value_or(-1);
         newDev->m_props.PCIDeviceWidth = safeGetI32(val, "PCIDeviceWidth").value_or(-1);
         newDev->m_props.VendorFlags.IntelFeatureFlagsUI32 = safeGetUI32(val, "VendorFlags").value_or(0);
-
+        if (newDev->IsVendor(kVendorId_nVidia))
+        {
+            newDev->m_props.VendorSpecific.nVidia.cudaComputeCapability_Major = 
+                safeGetI32(val, "cudaComputeCapability_Major").value_or(-1);
+            newDev->m_props.VendorSpecific.nVidia.cudaComputeCapability_Minor =
+                safeGetI32(val, "cudaComputeCapability_Minor").value_or(-1);
+        }
         newDev->m_props.MemoryBandWidthMax = safeGetI64(val, "MemoryBandWidthMax").value_or(-1);
 
         return newDev;
@@ -305,6 +311,13 @@ rapidjson::Value Device::serialize(AllocatorType& a)
     curDev.AddMember("MemoryFreqMinMHz", getProperties().MemoryFreqMinMHz, a);
 
     curDev.AddMember("VendorFlags", getProperties().VendorFlags.IntelFeatureFlagsUI32, a);
+    if (IsVendor(kVendorId_nVidia))
+    {
+        curDev.AddMember("cudaComputeCapability_Major", 
+            getProperties().VendorSpecific.nVidia.cudaComputeCapability_Major, a);
+        curDev.AddMember("cudaComputeCapability_Minor",
+            getProperties().VendorSpecific.nVidia.cudaComputeCapability_Minor, a);
+    }
 
     curDev.AddMember("IsHighPerformance", getProperties().IsHighPerformance, a);
     curDev.AddMember("IsMinimumPower", getProperties().IsMinimumPower, a);

--- a/LibXPUInfo_NVML.cpp
+++ b/LibXPUInfo_NVML.cpp
@@ -125,6 +125,24 @@ void Device::initNVMLDevice(nvmlDevice_t device)
         }
     }
 
+    int cccMajor = 0, cccMinor = 0;
+    result = nvmlDeviceGetCudaComputeCapability(device, &cccMajor, &cccMinor);
+    if (NVML_SUCCESS == result)
+    {
+        m_props.VendorSpecific.nVidia.cudaComputeCapability_Major = cccMajor;
+        m_props.VendorSpecific.nVidia.cudaComputeCapability_Minor = cccMinor;
+    }
+
+    // Currently only for multi-instance GPU (MIG)
+#if 0
+    nvmlDeviceAttributes_t devAttrs{};
+    result = nvmlDeviceGetAttributes(device, &devAttrs);
+    if (NVML_SUCCESS == result)
+    {
+
+    }
+#endif
+
 #if 0 // TODO: calculate MemoryBandWidthMax
     if (freqMem && busWidth)
     {

--- a/external/getNVMLDep.bat
+++ b/external/getNVMLDep.bat
@@ -5,7 +5,7 @@ set _EXTPATH=%~dp0
 @if EXIST %_EXTPATH%\NVML\lib\x64\nvml.lib if EXIST %_EXTPATH%\NVML\include\nvml.h goto NVML_DONE
 
 @echo Make sure env var https_proxy is set if needed!
-set NVML_BASE_NAME=cuda_nvml_dev-windows-x86_64-12.6.68-archive
+set NVML_BASE_NAME=cuda_nvml_dev-windows-x86_64-12.8.90-archive
 
 if NOT EXIST NVML.zip curl.exe -o NVML.zip https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/windows-x86_64/%NVML_BASE_NAME%.zip
 @if %ERRORLEVEL% neq 0 goto ERROR


### PR DESCRIPTION
For example, CUDA compute capability query is useful for determining whether a device can support Onnxruntime TensorRT EP. (Minumum of 75 required for TRT 10.8.)