### PR TITLE
Add TelemetryTracker::PeakUsage, serialize hybrid CPU details

### DIFF
--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -701,7 +701,7 @@ namespace XI
 
         struct PeakUsage
         {
-            PeakUsage max(const TimedRecord& r)
+            PeakUsage updatePeak(const TimedRecord& r)
             {
                 deviceMemoryUsedBytes = std::max(deviceMemoryUsedBytes, r.deviceMemoryUsedBytes);
                 gpu_mem_Adapter_Total = std::max(gpu_mem_Adapter_Total, r.gpu_mem_Adapter_Total);

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -676,7 +676,7 @@ namespace XI
             UI64 bw_write;
 
             // Resource usage
-            UI64 deviceMemoryUsedBytes; // Current process
+            UI64 deviceMemoryUsedBytes; // Current process, dedicated+shared (summed)
             UI64 deviceMemoryBudgetBytes;
 
             // Engine activity
@@ -687,9 +687,9 @@ namespace XI
             double pctCPU;
             double cpu_freq;
             double gpu_mem_Local;
-            double gpu_mem_Adapter_Total;
+            double gpu_mem_Adapter_Total; // All processes, dedicated + shared + GPU-related system memory
             double gpu_mem_Adapter_Shared;
-            double gpu_mem_Adapter_Dedicated;
+            double gpu_mem_Adapter_Dedicated; // All processes
 
             // System memory
             UI64 systemMemoryPhysicalAvailable;
@@ -698,6 +698,21 @@ namespace XI
             UI64 systemMemoryCommitPeak;
         };
         typedef std::vector<TimedRecord> TimedRecords;
+
+        struct PeakUsage
+        {
+            PeakUsage max(const TimedRecord& r)
+            {
+                deviceMemoryUsedBytes = std::max(deviceMemoryUsedBytes, r.deviceMemoryUsedBytes);
+                gpu_mem_Adapter_Total = std::max(gpu_mem_Adapter_Total, r.gpu_mem_Adapter_Total);
+                gpu_mem_Adapter_Dedicated = std::max(gpu_mem_Adapter_Dedicated, r.gpu_mem_Adapter_Dedicated);
+                return *this;
+            }
+            UI64 deviceMemoryUsedBytes; // Current process, dedicated+shared (summed)
+            double gpu_mem_Adapter_Total; // All processes, dedicated + shared + GPU-related system memory
+            double gpu_mem_Adapter_Dedicated; // All processes
+        };
+        PeakUsage getPeakUsage() const;
 
 #ifdef _WIN32
         static VOID CALLBACK

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -701,7 +701,7 @@ namespace XI
 
         struct PeakUsage
         {
-            PeakUsage updatePeak(const TimedRecord& r)
+            PeakUsage& updatePeak(const TimedRecord& r)
             {
                 deviceMemoryUsedBytes = std::max(deviceMemoryUsedBytes, r.deviceMemoryUsedBytes);
                 gpu_mem_Adapter_Total = std::max(gpu_mem_Adapter_Total, r.gpu_mem_Adapter_Total);

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -57,6 +57,16 @@ UI64 TelemetryTracker::getMaxMemUsage() const
 	return maxMemUsage;
 }
 
+TelemetryTracker::PeakUsage TelemetryTracker::getPeakUsage() const
+{
+	PeakUsage peak{};
+	for (const auto& rec : m_records)
+	{
+		peak = peak.max(rec);
+	}
+	return peak;
+}
+
 UI64 TelemetryTracker::getInitialMemUsage() const
 {
 	UI64 memUsage = 0;
@@ -475,6 +485,8 @@ void TelemetryTracker::InitPDH()
 	static const char* counterGPU_Memory_Dedicated = "*)\\Dedicated Usage";
 	static const char* counterGPU_Memory_Total = "*)\\Total Committed";
 	static const char* counterGPULocal_Memory[] = { "\\GPU Local Adapter Memory(luid_0x", "*)\\Local Usage" };
+	// TODO: Add "\\GPU Engine(*_luid_<luidPdhStr>*)\\Utilization Percentage", parse each engine of adapter per process, show totals per-engine
+	//		 Instance Naming: pid_<process_id>_luid_<adapter_luid>_engtype_<engine_type>
 
 	std::string luidPdhStr(getLuidStringForPDH(getDevice()->getLUIDAsStruct()));
 	std::string gpuMemoryLocalCounterPath = counterGPULocal_Memory[0] + luidPdhStr + counterGPULocal_Memory[1];

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -62,7 +62,7 @@ TelemetryTracker::PeakUsage TelemetryTracker::getPeakUsage() const
 	PeakUsage peak{};
 	for (const auto& rec : m_records)
 	{
-		peak = peak.updatePeak(rec);
+		peak.updatePeak(rec);
 	}
 	return peak;
 }

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -62,7 +62,7 @@ TelemetryTracker::PeakUsage TelemetryTracker::getPeakUsage() const
 	PeakUsage peak{};
 	for (const auto& rec : m_records)
 	{
-		peak = peak.max(rec);
+		peak = peak.updatePeak(rec);
 	}
 	return peak;
 }

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -389,7 +389,7 @@ int printXPUInfo(int argc, char* argv[])
     }
     catch (...)
     {
-        std::cout << "Unknwon exception initializing XPUInfo!\n";
+        std::cout << "Unknown exception initializing XPUInfo!\n";
         return -1;
     }
     return 0;


### PR DESCRIPTION
# Pull Request Overview
Adds peak usage tracking and extends JSON serialization to include hybrid CPU details.
- Introduces TelemetryTracker::PeakUsage and getPeakUsage() for summarizing peak device and GPU memory usage.
- Extends XPUInfo::serialize/deserialization to handle cpuSets and coreMasks mappings in JSON.
- Fixes a typo in an exception message and adds a TODO for future GPU engine telemetry.