### PR TITLE
Add lower-overhead mode to collect peak usage only

### DIFF
--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -281,11 +281,13 @@ namespace XI
         NONUMA_DISCRETE =   1 << 1
     };
 
-    inline double BtoGB(size_t n)
+    template <typename T>
+    inline double BtoGB(T n)
     {
         return (n / (1024.0 * 1024 * 1024));
     }
-    inline double BtoKB(size_t n)
+    template <typename T>
+    inline double BtoKB(T n)
     {
         return (n / 1024.0);
     }

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -708,17 +708,17 @@ namespace XI
             {
                 deviceMemoryUsedBytes = std::max(deviceMemoryUsedBytes, r.deviceMemoryUsedBytes);
                 gpu_mem_Adapter_Total = std::max(gpu_mem_Adapter_Total, r.gpu_mem_Adapter_Total);
-				gpu_mem_Adapter_Shared = std::max(gpu_mem_Adapter_Shared, r.gpu_mem_Adapter_Shared);
+                gpu_mem_Adapter_Shared = std::max(gpu_mem_Adapter_Shared, r.gpu_mem_Adapter_Shared);
                 gpu_mem_Adapter_Dedicated = std::max(gpu_mem_Adapter_Dedicated, r.gpu_mem_Adapter_Dedicated);
                 return *this;
             }
             UI64 deviceMemoryUsedBytes; // Current process, dedicated+shared (summed)
             double gpu_mem_Adapter_Total; // All processes, dedicated + shared + GPU-related system memory
-			double gpu_mem_Adapter_Shared; // All processes, shared memory
+            double gpu_mem_Adapter_Shared; // All processes, shared memory
             double gpu_mem_Adapter_Dedicated; // All processes
         };
         PeakUsage getPeakUsage() const;
-		PeakUsage getInitialUsage() const { return m_initialUsage; }
+        PeakUsage getInitialUsage() const { return m_initialUsage; }
 
 #ifdef _WIN32
         static VOID CALLBACK
@@ -742,7 +742,7 @@ namespace XI
         const DWORD m_msPeriod;
         TelemetryItem m_ResultMask = {};
         TelemetryItem m_ControlMask = {};
-		std::size_t m_numRecords = 0; // Number of records recorded so far
+        std::size_t m_numRecords = 0; // Number of records recorded so far
         std::ostream* m_pRealtime_ostr;
 
 #ifdef _WIN32
@@ -784,7 +784,7 @@ namespace XI
         double m_freqMaxHW = 0.;
         double m_freqMinHW = 0.;
         PeakUsage m_peakUsage;
-		PeakUsage m_initialUsage; // Initial usage at start of tracking
+        PeakUsage m_initialUsage; // Initial usage at start of tracking
         std::vector<TimedRecord> m_records;
         std::vector<zes_freq_handle_t> m_freqHandlesL0;
 

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -626,19 +626,6 @@ namespace XI
     class XPUINFO_EXPORT TelemetryTracker : public NoCopyAssign
     {
     public:
-        friend class Device;
-        TelemetryTracker(const DevicePtr& deviceToTrack, UI32 msPeriod, std::ostream* pRealTimeOutputStream = nullptr);
-        virtual ~TelemetryTracker() noexcept(false);
-
-        void start();
-        void stop();
-        String getLog() const;
-
-        UI64 getMaxMemUsage() const;
-        UI64 getInitialMemUsage() const;
-
-        const DevicePtr& getDevice() const;
-
         enum TelemetryItem : UI32
         {
             TELEMETRYITEM_UNKNOWN = 0,
@@ -657,8 +644,24 @@ namespace XI
 
             TELEMETRYITEM_SYSTEMMEMORY = 1 << 10,
 
+            // Flags that modify behavior
+            TELEMETRYITEM_PEAKUSAGE_ONLY = 1U << 31 // If set, only peak usage is recorded, no over-time data
+
             // TODO: PCI bandwidth?  Neither IGCL nor L0 working now.  Can derive from micro+mem_bw, though.
         };
+
+        TelemetryTracker(const DevicePtr& deviceToTrack, UI32 msPeriod, 
+            std::ostream* pRealTimeOutputStream = nullptr, TelemetryItem controlMask = TELEMETRYITEM_UNKNOWN);
+        virtual ~TelemetryTracker() noexcept(false);
+
+        void start();
+        void stop();
+        String getLog() const;
+
+        UI64 getMaxMemUsage() const;
+        UI64 getInitialMemUsage() const;
+
+        const DevicePtr& getDevice() const;
 
         struct TimedRecord
         {
@@ -705,14 +708,17 @@ namespace XI
             {
                 deviceMemoryUsedBytes = std::max(deviceMemoryUsedBytes, r.deviceMemoryUsedBytes);
                 gpu_mem_Adapter_Total = std::max(gpu_mem_Adapter_Total, r.gpu_mem_Adapter_Total);
+				gpu_mem_Adapter_Shared = std::max(gpu_mem_Adapter_Shared, r.gpu_mem_Adapter_Shared);
                 gpu_mem_Adapter_Dedicated = std::max(gpu_mem_Adapter_Dedicated, r.gpu_mem_Adapter_Dedicated);
                 return *this;
             }
             UI64 deviceMemoryUsedBytes; // Current process, dedicated+shared (summed)
             double gpu_mem_Adapter_Total; // All processes, dedicated + shared + GPU-related system memory
+			double gpu_mem_Adapter_Shared; // All processes, shared memory
             double gpu_mem_Adapter_Dedicated; // All processes
         };
         PeakUsage getPeakUsage() const;
+		PeakUsage getInitialUsage() const { return m_initialUsage; }
 
 #ifdef _WIN32
         static VOID CALLBACK
@@ -734,7 +740,9 @@ namespace XI
         std::mutex m_RecordMutex;
         const DevicePtr m_Device; // Tracker will keep device "alive" if needed
         const DWORD m_msPeriod;
-        TelemetryItem m_ResultMask;
+        TelemetryItem m_ResultMask = {};
+        TelemetryItem m_ControlMask = {};
+		std::size_t m_numRecords = 0; // Number of records recorded so far
         std::ostream* m_pRealtime_ostr;
 
 #ifdef _WIN32
@@ -775,6 +783,8 @@ namespace XI
         double m_freqMin = std::numeric_limits<double>::max();
         double m_freqMaxHW = 0.;
         double m_freqMinHW = 0.;
+        PeakUsage m_peakUsage;
+		PeakUsage m_initialUsage; // Initial usage at start of tracking
         std::vector<TimedRecord> m_records;
         std::vector<zes_freq_handle_t> m_freqHandlesL0;
 

--- a/LibXPUInfo_DXCore.cpp
+++ b/LibXPUInfo_DXCore.cpp
@@ -180,9 +180,9 @@ void XPUInfo::initDXCore(bool updateOnly)
                     );
 
                     printf("\tDedicated Video: %.3lf, System: %.3lf, Shared: %.3lf\n",
-                        DedicatedAdapterMemory / (1024 * 1024 * 1024.0),
-                        DedicatedSystemMemory / (1024 * 1024 * 1024.0),
-                        SharedSystemMemory / (1024 * 1024 * 1024.0));
+                        BtoGB(DedicatedAdapterMemory),
+                        BtoGB(DedicatedSystemMemory),
+                        BtoGB(SharedSystemMemory));
                 }
 
                 // TODO:  Does the budget and available amount below account for non-DX12 usage?
@@ -197,10 +197,10 @@ void XPUInfo::initDXCore(bool updateOnly)
                         if (memBudget.budget)
                         {
                             printf("\tLocal Mem:\n");
-                            printf("\t\tbudget: %.2lf\n", memBudget.budget / (1024 * 1024 * 1024.0));
-                            printf("\t\tcurrentUsage: %.2lf\n", memBudget.currentUsage / (1024 * 1024 * 1024.0));
-                            printf("\t\tavailableForReservation: %.2lf\n", memBudget.availableForReservation / (1024 * 1024 * 1024.0));
-                            printf("\t\tcurrentReservation: %.2lf\n", memBudget.currentReservation / (1024 * 1024 * 1024.0));
+                            printf("\t\tbudget: %.2lf\n", BtoGB(memBudget.budget));
+                            printf("\t\tcurrentUsage: %.2lf\n", BtoGB(memBudget.currentUsage));
+                            printf("\t\tavailableForReservation: %.2lf\n", BtoGB(memBudget.availableForReservation));
+                            printf("\t\tcurrentReservation: %.2lf\n", BtoGB(memBudget.currentReservation));
                         }
                     }
 
@@ -211,10 +211,10 @@ void XPUInfo::initDXCore(bool updateOnly)
                         if (memBudget.budget)
                         {
                             printf("\tNonLocal Mem:\n");
-                            printf("\t\tbudget: %.2lf\n", memBudget.budget / (1024 * 1024 * 1024.0));
-                            printf("\t\tcurrentUsage: %.2lf\n", memBudget.currentUsage / (1024 * 1024 * 1024.0));
-                            printf("\t\tavailableForReservation: %.2lf\n", memBudget.availableForReservation / (1024 * 1024 * 1024.0));
-                            printf("\t\tcurrentReservation: %.2lf\n", memBudget.currentReservation / (1024 * 1024 * 1024.0));
+                            printf("\t\tbudget: %.2lf\n", BtoGB(memBudget.budget));
+                            printf("\t\tcurrentUsage: %.2lf\n", BtoGB(memBudget.currentUsage));
+                            printf("\t\tavailableForReservation: %.2lf\n", BtoGB(memBudget.availableForReservation));
+                            printf("\t\tcurrentReservation: %.2lf\n", BtoGB(memBudget.currentReservation));
                         }
                     }
                 }
@@ -361,7 +361,7 @@ void ScopedRegisterNotification::ExampleNotificationFunc_DXCORE(DXCoreNotificati
 
         auto newBudget = xiDev->getMemUsage();
         std::cout << __FUNCTION__ << ": Budget changed for device " << convert(xiDev->name()) << 
-            " to " << std::setprecision(4) << newBudget.budget / (1024.0 * 1024*1024) << " GB" << std::endl;
+            " to " << std::setprecision(4) << BtoGB(newBudget.budget) << " GB" << std::endl;
     }
     break;
 

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -479,7 +479,7 @@ void TelemetryTracker::RecordNow()
 		}
 		if (m_pRealtime_ostr)
 		{
-			if (m_records.size() == 1)
+			if (m_numRecords == 0)
 			{
 				printRecordHeader(*m_pRealtime_ostr);
 			}
@@ -493,7 +493,7 @@ void TelemetryTracker::RecordNow()
 				printRecord(tempRecords.begin(), *m_pRealtime_ostr);
 			}
 		}
-		if (m_numRecords++ == 0ULL)
+		if (m_numRecords++ == 0)
 		{
 			m_initialUsage.updatePeak(rec);
 		}

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -477,10 +477,6 @@ void TelemetryTracker::RecordNow()
 		{
 			m_peakUsage.updatePeak(rec);
 		}
-		if (m_numRecords == 0ULL)
-		{
-			m_initialUsage.updatePeak(rec);
-		}
 		if (m_pRealtime_ostr)
 		{
 			if (m_records.size() == 1)
@@ -497,7 +493,10 @@ void TelemetryTracker::RecordNow()
 				printRecord(tempRecords.begin(), *m_pRealtime_ostr);
 			}
 		}
-		++m_numRecords;
+		if (m_numRecords++ == 0ULL)
+		{
+			m_initialUsage.updatePeak(rec);
+		}
 	}
 }
 

--- a/LibXPUInfo_TelemetryTracker.cpp
+++ b/LibXPUInfo_TelemetryTracker.cpp
@@ -114,10 +114,10 @@ void TelemetryTracker::printRecord(TimedRecords::const_iterator it, std::ostream
 
 #if defined(_WIN32) && !defined(_M_ARM64)
 	ostr << "," << rec.pctCPU << "," << rec.cpu_freq / (100.0);
-	ostr << "," << rec.gpu_mem_Local / (1024.0 * 1024 * 1024);
-	ostr << "," << rec.gpu_mem_Adapter_Shared / (1024.0 * 1024 * 1024);
-	ostr << "," << rec.gpu_mem_Adapter_Dedicated / (1024.0 * 1024 * 1024);
-	ostr << "," << rec.gpu_mem_Adapter_Total / (1024.0 * 1024 * 1024);
+	ostr << "," << BtoGB(rec.gpu_mem_Local);
+	ostr << "," << BtoGB(rec.gpu_mem_Adapter_Shared);
+	ostr << "," << BtoGB(rec.gpu_mem_Adapter_Dedicated);
+	ostr << "," << BtoGB(rec.gpu_mem_Adapter_Total);
 #endif
 
 	if (m_ResultMask & TELEMETRYITEM_FREQUENCY)
@@ -205,10 +205,10 @@ void TelemetryTracker::printRecord(TimedRecords::const_iterator it, std::ostream
 	if (m_ResultMask & TELEMETRYITEM_SYSTEMMEMORY)
 	{
         SaveRestoreIOSFlags saveFlags(ostr);
-		ostr << "," << std::setprecision(5) << (rec.systemMemoryPhysicalAvailable / (1024.0 * 1024 * 1024))
-			<< "," << (rec.systemMemoryCommitTotal / (1024.0 * 1024 * 1024))
-			<< "," << (rec.systemMemoryCommitLimit / (1024.0 * 1024 * 1024))
-			<< "," << (rec.systemMemoryCommitPeak / (1024.0 * 1024 * 1024))
+		ostr << "," << std::setprecision(5) << BtoGB(rec.systemMemoryPhysicalAvailable)
+			<< "," << BtoGB(rec.systemMemoryCommitTotal)
+			<< "," << BtoGB(rec.systemMemoryCommitLimit)
+			<< "," << BtoGB(rec.systemMemoryCommitPeak)
 			;
 	}
 

--- a/LibXPUInfo_Util.h
+++ b/LibXPUInfo_Util.h
@@ -217,7 +217,7 @@ public:
     ~SaveRestoreIOSFlags()
     {
         m_stream.precision(m_precision);
-        m_stream.setf(m_Flags);
+        m_stream.setf(m_Flags, -1); // set to original flags
     }
 
 protected:

--- a/LibXPUInfo_Util.h
+++ b/LibXPUInfo_Util.h
@@ -213,15 +213,17 @@ class SaveRestoreIOSFlags
 {
 public:
     typedef std::basic_ios<CharT, Traits> Stream;
-    SaveRestoreIOSFlags(Stream& s): m_stream(s), m_Flags(s.flags()) {}
+    SaveRestoreIOSFlags(Stream& s): m_stream(s), m_Flags(s.flags()), m_precision(s.precision()) {}
     ~SaveRestoreIOSFlags()
     {
+        m_stream.precision(m_precision);
         m_stream.setf(m_Flags);
     }
 
 protected:
     Stream& m_stream;
     const std::ios::fmtflags m_Flags;
+    std::streamsize m_precision;
 };
 
 } // XI

--- a/LibXPUInfo_WMI.cpp
+++ b/LibXPUInfo_WMI.cpp
@@ -548,10 +548,10 @@ WString SystemInfo::getMemoryDescription() const
         {
             os << ", ";
         }
-        os << count << L" x " << dev.Capacity / (1024.0 * 1024 * 1024) << "GB at " << dev.SpeedMHz << "MHz";
+        os << count << L" x " << BtoGB(dev.Capacity) << "GB at " << dev.SpeedMHz << "MHz";
         ++i;
     }
-    os << " (" << totalMem / (1024.0 * 1024 * 1024) << "GB Total)";
+    os << " (" << BtoGB(totalMem) << "GB Total)";
 #endif
     return os.str();
 }
@@ -634,7 +634,7 @@ std::ostream& operator<<(std::ostream& os, const SystemInfo& si)
     {
         os << left << setw(colW) << "\tSystemType:" << convert(si.SystemType) << endl;
     }
-    os << left << setw(colW) << "\tTotalPhysicalMemory (GB):" << setprecision(4) << si.TotalPhysicalMemory / (1024.0 * 1024 * 1024) << endl;
+    os << left << setw(colW) << "\tTotalPhysicalMemory (GB):" << setprecision(4) << BtoGB(si.TotalPhysicalMemory) << endl;
     if (si.OS.TotalVirtualMemorySizeKB)
     {
         os << left << setw(colW) << "\tTotalVirtualMemory (GB):" << setprecision(4) << si.OS.TotalVirtualMemorySizeKB / (1024.0 * 1024) << endl;

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -218,7 +218,7 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
         
         if (peakOnly)
         {
-			tt = std::make_unique<XI::TelemetryTracker>(telemDevice, telemInterval_ms, nullptr, XI::TelemetryTracker::TELEMETRYITEM_PEAKUSAGE_ONLY);
+            tt = std::make_unique<XI::TelemetryTracker>(telemDevice, telemInterval_ms, nullptr, XI::TelemetryTracker::TELEMETRYITEM_PEAKUSAGE_ONLY);
         }
         else
         {
@@ -233,9 +233,9 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
 
         std::cout << std::right << std::setw(40) << "Memory usage summary for device: " << XI::convert(telemDevice->name()) << std::endl;
         auto peak = tt->getPeakUsage();
-		auto initial = tt->getInitialUsage();
+        auto initial = tt->getInitialUsage();
         XI::SaveRestoreIOSFlags sr(std::cout);
-		auto printPeak = [](const std::string& label, const XI::TelemetryTracker::PeakUsage& peak) {
+        auto printPeak = [](const std::string& label, const XI::TelemetryTracker::PeakUsage& peak) {
             std::cout.precision(2);
             std::cout << std::fixed;
             std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << peak.deviceMemoryUsedBytes / (1024.0 * 1024 * 1024) << std::endl;
@@ -243,9 +243,9 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
             std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << peak.gpu_mem_Adapter_Shared / (1024.0 * 1024 * 1024) << std::endl;
             std::cout << std::right << std::setw(40) << (label + " Dedicated Device Mem (GB): ") << peak.gpu_mem_Adapter_Dedicated / (1024.0 * 1024 * 1024) << std::endl;
             };
-		printPeak("Peak", peak);
-		printPeak("Initial", initial);
-		tt.reset(); // Stop telemetry and print results
+        printPeak("Peak", peak);
+        printPeak("Initial", initial);
+        tt.reset(); // Stop telemetry and print results
     }
     std::cout << std::endl << xi << std::endl;
     return 0;
@@ -300,9 +300,9 @@ int printXPUInfo(int argc, char* argv[])
             }
         }
         else if (arg == "-peak_only")
-		{
-			peakOnly = true;
-		}
+        {
+            peakOnly = true;
+        }
         else if (arg == "-igcl_l0_enable")
         {
             additionalAPIs |= XI::API_TYPE_IGCL_L0;

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -238,10 +238,10 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
         auto printPeak = [](const std::string& label, const XI::TelemetryTracker::PeakUsage& peak) {
             std::cout.precision(2);
             std::cout << std::fixed;
-            std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << peak.deviceMemoryUsedBytes / (1024.0 * 1024 * 1024) << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Device Mem, All Processes (GB): ") << peak.gpu_mem_Adapter_Total / (1024.0 * 1024 * 1024) << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << peak.gpu_mem_Adapter_Shared / (1024.0 * 1024 * 1024) << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Dedicated Device Mem (GB): ") << peak.gpu_mem_Adapter_Dedicated / (1024.0 * 1024 * 1024) << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << peak.deviceMemoryUsedBytes / BYTES_TO_GB << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Device Mem, All Processes (GB): ") << peak.gpu_mem_Adapter_Total / BYTES_TO_GB << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << peak.gpu_mem_Adapter_Shared / BYTES_TO_GB << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Dedicated Device Mem (GB): ") << peak.gpu_mem_Adapter_Dedicated / BYTES_TO_GB << std::endl;
             };
         printPeak("Peak", peak);
         printPeak("Initial", initial);

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -238,11 +238,10 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
         auto printPeak = [](const std::string& label, const XI::TelemetryTracker::PeakUsage& peak) {
             std::cout.precision(2);
             std::cout << std::fixed;
-            constexpr double BYTES_TO_GB = 1024.0 * 1024.0 * 1024.0;
-            std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << peak.deviceMemoryUsedBytes / BYTES_TO_GB << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Device Mem, All Processes (GB): ") << peak.gpu_mem_Adapter_Total / BYTES_TO_GB << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << peak.gpu_mem_Adapter_Shared / BYTES_TO_GB << std::endl;
-            std::cout << std::right << std::setw(40) << (label + " Dedicated Device Mem (GB): ") << peak.gpu_mem_Adapter_Dedicated / BYTES_TO_GB << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << BtoGB(peak.deviceMemoryUsedBytes) << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Device Mem, All Processes (GB): ") << BtoGB(peak.gpu_mem_Adapter_Total) << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << BtoGB(peak.gpu_mem_Adapter_Shared) << std::endl;
+            std::cout << std::right << std::setw(40) << (label + " Dedicated Device Mem (GB): ") << BtoGB(peak.gpu_mem_Adapter_Dedicated) << std::endl;
             };
         printPeak("Peak", peak);
         printPeak("Initial", initial);

--- a/TestLibXPUInfo/TestLibXPUInfo.cpp
+++ b/TestLibXPUInfo/TestLibXPUInfo.cpp
@@ -238,6 +238,7 @@ int runTelemetry(XI::UI32 telemInterval_ms, XI::UI32 telem_gpu_idx, bool peakOnl
         auto printPeak = [](const std::string& label, const XI::TelemetryTracker::PeakUsage& peak) {
             std::cout.precision(2);
             std::cout << std::fixed;
+            constexpr double BYTES_TO_GB = 1024.0 * 1024.0 * 1024.0;
             std::cout << std::right << std::setw(40) << (label + " Device Mem (GB): ") << peak.deviceMemoryUsedBytes / BYTES_TO_GB << std::endl;
             std::cout << std::right << std::setw(40) << (label + " Device Mem, All Processes (GB): ") << peak.gpu_mem_Adapter_Total / BYTES_TO_GB << std::endl;
             std::cout << std::right << std::setw(40) << (label + " Shared Device Mem (GB): ") << peak.gpu_mem_Adapter_Shared / BYTES_TO_GB << std::endl;

--- a/utility/LibXPUInfo_D3D12Utility.cpp
+++ b/utility/LibXPUInfo_D3D12Utility.cpp
@@ -45,8 +45,8 @@ bool CreateD3D12DeviceAndAllocateResource(IUnknown* pAdapter, size_t sizeInBytes
             }
             else if (memBudget.budget < sizeInBytes)
             {
-                std::cout << __FUNCTION__ << ": Memory requested, " << sizeInBytes / (1024.0 * 1024 * 1024) <<
-                    " GB, exceeds available, " << memBudget.budget / (1024.0 * 1024 * 1024) << " GB\n";
+                std::cout << __FUNCTION__ << ": Memory requested, " << BtoGB(sizeInBytes) <<
+                    " GB, exceeds available, " << BtoGB(memBudget.budget) << " GB\n";
             }
             else
             {


### PR DESCRIPTION
### Key changes:
- Introduces a peak-only telemetry mode via TELEMETRYITEM_PEAKUSAGE_ONLY flag to reduce memory overhead
- Fixes SaveRestoreIOSFlags to properly restore stream precision
- Replaces inline byte-to-GB conversion calculations with reusable BtoGB() template function calls
