### PR TITLE
Set env var to enable L0 Sysman before calling zeInit

### DIFF
--- a/LibXPUInfo_L0.cpp
+++ b/LibXPUInfo_L0.cpp
@@ -461,6 +461,9 @@ static ze_result_t safeInitL0()
 	ze_result_t result = ZE_RESULT_ERROR_UNKNOWN;
 	__try
 	{
+		// Set env var for Sysman
+		_putenv_s("ZES_ENABLE_SYSMAN", "1");
+
 		// Initialize the driver
 		// TODO: Once a loader is available supporting zeInitDrivers(), use it instead of zeInit. 
 		//       See https://spec.oneapi.io/level-zero/latest/core/api.html#zeinitdrivers.


### PR DESCRIPTION
The Level Zero API requires the environment variable ZES_ENABLE_SYSMAN be set to 1 prior to calling zeInit() if not using the newer method calling zesInit().

Why this change is needed:
- Previously, the Intel Graphics Control Center was installed as a service named _igccservice_, which created a system-wide setting of this environment variable, masking the need for it in LibXPUInfo.
- Newer versions of Intel Graphics Software do not install the above component, so a system that never had Intel Graphics Control Center installed would not have ZES_ENABLE_SYSMAN set, and the fields populated by Sysman calls like the PCI bus generation and width would not be set.

[See Level Zero Sysman Programming Guide](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/sysman/PROG.html)