### PR TITLE
Filter bad USB adapter and other updates

### DIFF
--- a/HybridDetect/HybridDetect.h
+++ b/HybridDetect/HybridDetect.h
@@ -383,6 +383,7 @@ typedef struct _PROCESSOR_INFO
 	bool								hybrid = false;
 	bool								turboBoost = false;
 	bool								turboBoost3_0 = false;
+	unsigned							microcodeRevision;
 	std::vector<GROUP_INFO>				groups;
 	std::vector<NUMA_NODE_INFO>			nodes;
 	std::vector<CACHE_INFO>				caches;
@@ -856,6 +857,30 @@ inline void UpdateProcessorInfo(PROCESSOR_INFO& procInfo)
 #endif
 }
 
+inline bool GetMicrocodeRevision(uint32_t& microcodeRevision)
+{
+	bool success = false;
+
+	// Set a default value in case regkey queries fail.
+	microcodeRevision = 0;
+
+#ifdef HYBRIDDETECT_OS_WIN
+	HKEY hKey;
+	uint64_t updateRevision = 0u;
+	uint32_t entryLengthInBytes = sizeof(updateRevision);
+
+	if (ERROR_SUCCESS == RegOpenKeyExA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", 0, KEY_READ, &hKey)) {
+		if (ERROR_SUCCESS == RegGetValueA(hKey, nullptr, "Update Revision", RRF_RT_REG_BINARY, nullptr, (PVOID)&updateRevision, (LPDWORD)&entryLengthInBytes)) {
+			microcodeRevision = static_cast<uint32_t>(updateRevision >> (entryLengthInBytes == sizeof(uint64_t)) * 32u);
+			success = true;
+		}
+
+		RegCloseKey(hKey);
+	}
+#endif
+	return success;
+}
+
 // Calls CPUID & GetLogicalProcessors & CallNTPowerInformation to fill in PROCESSOR_INFO
 inline void GetProcessorInfo(PROCESSOR_INFO& procInfo)
 {
@@ -994,6 +1019,8 @@ inline void GetProcessorInfo(PROCESSOR_INFO& procInfo)
 		procInfo.turboBoost = bits[1];
 		procInfo.turboBoost3_0 = bits[14];
 	}
+
+	GetMicrocodeRevision(procInfo.microcodeRevision);
 
 #ifdef HYBRIDDETECT_OS_WIN
 	DWORD_PTR           affinityMask;

--- a/LibXPUInfo.cpp
+++ b/LibXPUInfo.cpp
@@ -668,13 +668,23 @@ void XPUInfo::initDXGI(APIType initMask)
 {
     DWORD dxgiFactoryFlags = 0;
 #ifdef _DEBUG
-    dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+    //dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG; // Enable for debug layer
+	constexpr bool printToConsole = true;
+#else
+	constexpr bool printToConsole = false;
 #endif
 
     WRL::ComPtr<IDXGIFactory4> currentFactory;
-    CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(currentFactory.GetAddressOf())); // List of devices created here - need to re-init if devices change
-    WRL::ComPtr<IDXGIAdapter1> adapter;
+    HRESULT hr = CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(currentFactory.GetAddressOf())); // List of devices created here - need to re-init if devices change
+	if (FAILED(hr))
+	{
+        DebugStream dStr(printToConsole);
+        dStr << "Failed to create DXGI Factory, HRESULT = 0x" << std::hex << hr << std::dec << std::endl;
+        return;
+	}
+    XPUINFO_REQUIRE(!!currentFactory);
 
+    WRL::ComPtr<IDXGIAdapter1> adapter;
     for (UINT adapterIndex = 0;
         currentFactory->EnumAdapters1(adapterIndex, &adapter) != DXGI_ERROR_NOT_FOUND;
         ++adapterIndex)
@@ -683,18 +693,17 @@ void XPUInfo::initDXGI(APIType initMask)
         HRESULT hres = adapter->GetDesc1(&desc);
         if (SUCCEEDED(hres))
         {
-            if ((desc.VendorId == 0x1414) && (desc.DeviceId == 0x8c))
-            {
-                continue; // Skip "Microsoft Basic Render Driver"
-            }
+			if ((desc.VendorId == 0x1414) && (desc.DeviceId == 0x8c))
+			{
+				continue; // Skip "Microsoft Basic Render Driver"
+			}
             else
             {
 				{
 					DebugStreamW dStr(false);
-					dStr << L"Adapter " << adapterIndex << L": " << desc.Description << L", Vendor = " << std::hex << desc.VendorId << std::dec << std::endl;
+					dStr << L"DXGI Adapter " << adapterIndex << L": " << desc.Description << L", Vendor = " << std::hex << desc.VendorId << std::dec << std::endl;
 				}
-				//LARGE_INTEGER ver;
-				//hres = adapter->CheckInterfaceSupport(__uuidof(IDXGIDevice), &ver); // Essentially the DX10 driver version - seems to be valid even for RDP virtual adapter
+
 				DevicePtr newDevice(new Device(adapterIndex, &desc));
 				if (!!newDevice && newDevice->driverVersion().Valid())
 				{
@@ -720,14 +729,14 @@ void XPUInfo::initDXGI(APIType initMask)
     }
 
 	// Show displays connected
-#if 0
+#if 0 && defined(_DEBUG)
 	{
 		std::ostream& dStr = std::cout;
 		int maxDevNum = 0;
 		DISPLAY_DEVICEA tempDD, monitor;
 		ZeroMemory(&tempDD, sizeof(DISPLAY_DEVICEA));
 		tempDD.cb = sizeof(DISPLAY_DEVICEA);
-		monitor.cb = sizeof(DISPLAY_DEVICEA);
+		monitor.cb = sizeof(DISPLAY_DEVICEA);	
 		DISPLAY_DEVICEA tempDD2;
 		ZeroMemory(&tempDD2, sizeof(DISPLAY_DEVICEA));
 		tempDD2.cb = sizeof(DISPLAY_DEVICEA);
@@ -995,11 +1004,12 @@ XPUInfo::XPUInfo(APIType initMask, const RuntimeNames& runtimeNamesToTrack, size
 #ifdef XPUINFO_USE_SETUPAPI
 	if (initMask & API_TYPE_SETUPAPI)
 	{
-		m_pSetupInfo.reset(new SetupDeviceInfo);
+		m_pSetupInfo = std::make_shared<SetupDeviceInfo>();
 		bool bSDIMatchFound = false;
-		for (auto& devPair : m_Devices)
+		//for (auto& devPair : m_Devices)
+		for (decltype(m_Devices)::const_iterator it = m_Devices.begin(); it != m_Devices.end();)
 		{
-			auto& device = devPair.second;
+			auto& device = it->second;
 			DriverInfoPtr pSDI = m_pSetupInfo->getByLUID(device->getLUID());
 			if (!pSDI)
 			{
@@ -1017,6 +1027,12 @@ XPUInfo::XPUInfo(APIType initMask, const RuntimeNames& runtimeNamesToTrack, size
 			}
 			if (pSDI)
 			{
+				if (!pSDI->isValidXPU())
+				{
+					// Remove this device!
+					it = m_Devices.erase(it);
+					continue;
+				}
 				if (!device->m_props.pDriverInfo)
 				{
 					device->m_props.pDriverInfo = pSDI;
@@ -1052,7 +1068,8 @@ XPUInfo::XPUInfo(APIType initMask, const RuntimeNames& runtimeNamesToTrack, size
 					}
 				}
 			}
-		}
+			++it;
+		} // devices
 		if (bSDIMatchFound)
 		{
 			m_UsedAPIs = m_UsedAPIs | API_TYPE_SETUPAPI;
@@ -1278,6 +1295,15 @@ float DriverInfo::DriverAgeInYears() const
 }
 #endif
 
+bool DriverInfo::isValidXPU() const
+{
+#ifdef _WIN32
+	return XI::LuidToUI64(DeviceLUID) && (EnumeratorName == L"PCI");
+#else
+	return true;
+#endif
+}
+
 std::ostream& operator<<(std::ostream& ostr, const DevicePtr& xiDev)
 {
 	if (!!xiDev)
@@ -1403,6 +1429,10 @@ std::ostream& operator<<(std::ostream& ostr, const Device& xiDev)
 		if (devProps.pDriverInfo->DeviceInstanceId.length())
 		{
 			ostr << "\tDevice Instance ID: " << XI::convert(devProps.pDriverInfo->DeviceInstanceId) << std::endl;
+		}
+		if (devProps.pDriverInfo->DeviceService.length())
+		{
+			ostr << "\tDevice Service: " << XI::convert(devProps.pDriverInfo->DeviceService) << std::endl;
 		}
 	}
 
@@ -1737,6 +1767,10 @@ void DeviceCPU::printInfo(std::ostream& ostr, const SystemInfo* pSysInfo) const
 			ostr << std::endl;
 #else
 			ostr << "cpuid.1.eax = 0x" << std::hex << std::setw(8) << std::right << std::setfill('0') << basicCPUID << std::dec << std::endl;
+			if (m_pProcInfo->IsIntel() && m_pProcInfo->microcodeRevision)
+			{
+				ostr << std::right << std::setfill(' ') << std::setw(3+12+2+24+4) << "Microcode revision = 0x" << std::hex << std::setw(4) << std::right << std::setfill('0') << m_pProcInfo->microcodeRevision << std::dec << std::endl;
+			}
 #endif
 			ostr << std::setfill(' ');
 		}
@@ -1847,7 +1881,10 @@ DXCoreAdapterMemoryBudget XI::Device::getMemUsage() const
 #ifdef XPUINFO_USE_DXCORE
 	if (XPUInfo::hasDXCore())
 	{
-		return getMemUsage_DXCORE();
+		if (getCurrentAPIs() & XI::APIType::API_TYPE_DXCORE)
+		{
+			return getMemUsage_DXCORE();
+		}
 	}
 #endif
 #endif

--- a/LibXPUInfo.h
+++ b/LibXPUInfo.h
@@ -377,6 +377,8 @@ namespace XI
         WString DriverVersion;
         WString DriverInfSection; // DEVPKEY_Device_DriverInfSection
         WString DeviceInstanceId; // DEVPKEY_Device_InstanceId, to correlate with WMI data
+        WString EnumeratorName;   // DEVPKEY_Device_EnumeratorName
+        WString DeviceService;    // DEVPKEY_Device_Service
         PCIAddressType LocationInfo;
 #ifdef _WIN32
         FILETIME DriverDate = {};   // When driver was created/published
@@ -385,6 +387,7 @@ namespace XI
         static float DriverAgeInYears(const FILETIME& inFileTime, SYSTEMTIME& outSysTime);
 #endif
         float DriverAgeInYears() const;
+        bool isValidXPU() const; 
     };
     typedef std::shared_ptr<DriverInfo> DriverInfoPtr;
 
@@ -407,6 +410,7 @@ namespace XI
 
     const UINT kVendorId_Intel = 0x8086;
     const UINT kVendorId_nVidia = 0x10de;
+    const UINT kVendorId_AMD = 0x1002;
 
     // Properties that are frequently used or common to most devices
     struct XPUINFO_EXPORT DeviceProperties

--- a/LibXPUInfo_DXCore.cpp
+++ b/LibXPUInfo_DXCore.cpp
@@ -131,6 +131,10 @@ void XPUInfo::initDXCore(bool updateOnly)
             // HardwareID
             DXCoreHardwareID hwID;
             THROW_IF_FAILED(currAdapter->GetProperty(DXCoreAdapterProperty::HardwareID, &hwID));
+            if ((hwID.vendorID == 0x1414) && (hwID.deviceID == 0x8c))
+            {
+                return; // Skip "Microsoft Basic Render Driver"
+            }
 
             LUID curLUID{};
             THROW_IF_FAILED(currAdapter->GetProperty(DXCoreAdapterProperty::InstanceLuid, &curLUID));
@@ -178,7 +182,7 @@ void XPUInfo::initDXCore(bool updateOnly)
                 {
                     printf("Description: %s (%s), LUID=0x%llx, Version %hu.%hu.%hu.%hu\n", driverDescription.c_str(),
                         isIntegratedValid ? (isIntegrated ? "Integrated" : "Discrete") : "UNKNOWN_UMA",
-                        *(uint64_t*)&curLUID,
+                        LuidToUI64(curLUID),
                         driverVersion[3],
                         driverVersion[2],
                         driverVersion[1],

--- a/LibXPUInfo_JSON.cpp
+++ b/LibXPUInfo_JSON.cpp
@@ -92,6 +92,7 @@ bool XPUInfo::serialize(rapidjson::Document& doc)
         objCPU.AddMember("Hybrid", pi->hybrid, a);
         objCPU.AddMember("FeatureFlagsUI64", pi->flagsUI64, a);
         objCPU.AddMember("CPUID_1_EAX", pi->cpuid_1_eax, a);
+        objCPU.AddMember("microcodeRevision", pi->microcodeRevision, a);
 
         // cpuSets: std::map<unsigned, std::vector<ULONG>>
         objCPU.AddMember("cpuSets", serializeMapToJson(doc, pi->cpuSets), a);
@@ -256,6 +257,8 @@ DevicePtr Device::deserialize(const rapidjson::Value& val)
             newDev->m_props.pDriverInfo->DriverVersion = safeGetWString(valDI, "DriverVersion");
             newDev->m_props.pDriverInfo->DriverInfSection = safeGetWString(valDI, "DriverInfSection");
             newDev->m_props.pDriverInfo->DeviceInstanceId = safeGetWString(valDI, "DeviceInstanceId");
+            newDev->m_props.pDriverInfo->EnumeratorName = safeGetWString(valDI, "EnumeratorName");
+            newDev->m_props.pDriverInfo->DeviceService = safeGetWString(valDI, "DeviceService");
 
             if (valDI.HasMember("LocationInfo"))
             {
@@ -327,6 +330,8 @@ rapidjson::Value Device::serialize(AllocatorType& a)
         curDI.AddMember("DriverInfSection", XI::convert(pDI->DriverInfSection), a);
         curDI.AddMember("DeviceInstanceId", XI::convert(pDI->DeviceInstanceId), a);
         curDI.AddMember("LocationInfo", pDI->LocationInfo.serialize(a), a);
+        curDI.AddMember("EnumeratorName", XI::convert(pDI->EnumeratorName), a);
+        curDI.AddMember("DeviceService", XI::convert(pDI->DeviceService), a);
 #ifdef _WIN32
         FILETIME ftime;
         ftime = pDI->DriverDate;
@@ -495,6 +500,7 @@ DeviceCPU::DeviceCPU(const rapidjson::Value& val) :
     m_pProcInfo->hybrid = JSON::safeGetBool(val, "Hybrid").value_or(false);
     m_pProcInfo->flagsUI64 = JSON::safeGetUI64(val, "FeatureFlagsUI64").value_or(0);
     m_pProcInfo->cpuid_1_eax = JSON::safeGetUI32(val, "CPUID_1_EAX").value_or(0);
+    m_pProcInfo->microcodeRevision = JSON::safeGetUI32(val, "microcodeRevision").value_or(0);
 
     if (val.HasMember("cpuSets") && val["cpuSets"].IsObject())
     {

--- a/LibXPUInfo_NVML.cpp
+++ b/LibXPUInfo_NVML.cpp
@@ -226,15 +226,18 @@ void XPUInfo::initNVML()
     nvmlReturn_t result = nvmlInit();
 #endif
 
+    constexpr bool printToConsole = false;
+
     if (NVML_SUCCESS == result)
     {
         UI32 device_count=0;
         result = nvmlDeviceGetCount(&device_count);
+        DebugStream dStr(printToConsole);
+        dStr << "NVML: Initialized" << std::endl;
+
         if (NVML_SUCCESS == result)
         {
-#ifndef __linux__
-            m_UsedAPIs = m_UsedAPIs | API_TYPE_NVML;
-#endif
+            dStr << "NVML:\tDevice count: " << device_count << std::endl;
             for (UI32 i = 0; i < device_count; ++i)
             {
                 nvmlDevice_t device = nullptr;
@@ -257,7 +260,8 @@ void XPUInfo::initNVML()
                         {
                             pciAddr.function = atoi(funcStr.c_str());
                         }
-
+                        dStr << "NVML:\t\tDevice " << i << ": " << pciAddr.domain << ":" << pciAddr.bus << ":" << pciAddr.device << "." << pciAddr.function
+                            << " (PCI ID: " << std::hex << pci.pciDeviceId << std::dec << ")" << std::endl;
 #ifdef __linux__
 // Add to devices
 						DXGI_ADAPTER_DESC1 desc1{};
@@ -328,12 +332,35 @@ void XPUInfo::initNVML()
 							}
 						}
 #else
-                        for (auto& [luid, dev] : m_Devices)
+                        int numnVidiaDevices = 0;
+                        for (auto& devPair : m_Devices)
                         {
-                            if (dev->getProperties().PCIAddress == pciAddr)
+                            auto& dev = devPair.second;
+                            if (dev->IsVendor(kVendorId_nVidia))
                             {
-                                dev->initNVMLDevice(device);
-                                break;
+                                ++numnVidiaDevices;
+
+                                if (dev->getProperties().PCIAddress == pciAddr)
+                                {
+                                    dev->initNVMLDevice(device);
+                                    m_UsedAPIs = m_UsedAPIs | API_TYPE_NVML;
+                                    break;
+                                }
+                            }
+                        }
+                        // If 1 nVidia device and PCI address did not match, assume it is the correct device
+                        if ((device_count == 1) && (numnVidiaDevices==1) && !(m_UsedAPIs & API_TYPE_NVML))
+                        {
+                            dStr << "NVML:\t\tFound " << numnVidiaDevices << " nVidia devices, but none matched NVML PCI info!" << std::endl;
+                            for (auto& devPair : m_Devices)
+                            {
+                                auto& dev = devPair.second;
+                                if (dev->IsVendor(kVendorId_nVidia))
+                                {
+                                    dev->initNVMLDevice(device);
+                                    m_UsedAPIs = m_UsedAPIs | API_TYPE_NVML;
+                                    break;
+                                }
                             }
                         }
 #endif
@@ -344,7 +371,6 @@ void XPUInfo::initNVML()
 #ifndef __linux__
         else
         {
-            DebugStream dStr(true);
             dStr << "Failed to query device count: " << nvmlErrorString(result) << std::endl;
         }
 #endif

--- a/LibXPUInfo_SetupAPI.cpp
+++ b/LibXPUInfo_SetupAPI.cpp
@@ -107,9 +107,10 @@ namespace //private
 {
 	bool getInfoForClass(const GUID* devClass, std::vector<DriverInfoPtr>& outInfos)
 	{
+		// We need to include all Enumerator classes, 
+		//   then filter out non-GPU devices under SWD or USB
 		HDEVINFO m_info = SetupDiGetClassDevsW(devClass,
-			L"PCI", // Filter out remote desktop which is "SWD"
-			nullptr, DIGCF_PRESENT);
+			nullptr, nullptr, DIGCF_PRESENT);
 		HYBRIDDETECT_DEBUG_REQUIRE(m_info != INVALID_HANDLE_VALUE);
 
 		SP_DEVINFO_DATA devInfoData;
@@ -130,26 +131,9 @@ namespace //private
 				dStr << L" with " << numKeys << L" keys";
 			}
 
-			DEVPROPTYPE PropType;
 			DWORD nameSize = 0;
 			std::vector<wchar_t> tempStr;
 			tempStr.resize(256);
-
-			/*
-			if (SetupDiGetDevicePropertyW(
-				m_info,
-				&devInfoData,
-				&DEVPKEY_Device_EnumeratorName,
-				&PropType,
-				(PBYTE)tempStr.data(),
-				(DWORD)tempStr.size(),
-				&nameSize,
-				0))
-			{
-				// Should be PCI unless filter above changed
-				dStr << L" at \"" << tempStr.data() << L"\"";
-			}
-			*/
 
 			if (sdiGetProp(m_info, tempStr, &devInfoData, &DEVPKEY_Device_DriverDesc, curInfo->DriverDesc))
 			{
@@ -169,11 +153,31 @@ namespace //private
 				dStr << L",(DEVPKEY_Device_DeviceDesc: " << GetErrorCodeStr(err) << ")";
 			}
 
+			/* If you are iterating via SetupDiGetClassDevs, pull the DEVPKEY_Device_EnumeratorName property. 
+			   If the class is GUID_DEVCLASS_DISPLAY but the enumerator string isn't "PCI", you can confidently 
+			   flag it as a virtual adapter.*/
+			XI::WString& enumeratorName = curInfo->EnumeratorName;
+			if (sdiGetProp(m_info, tempStr, &devInfoData, &DEVPKEY_Device_EnumeratorName, enumeratorName))
+			{
+				dStr << L", " << enumeratorName;
+				if (enumeratorName == L"SWD")
+				{
+					dStr << L", SKIPPED\n";
+					continue; // Skip software devices like "Microsoft Basic Render Driver"
+				}
+			}
+			else
+			{
+				DWORD err = GetLastError();
+				dStr << L",(DEVPKEY_Device_EnumeratorName: " << GetErrorCodeStr(err) << ")";
+			}
+
 			if (sdiGetProp(m_info, tempStr, &devInfoData, &DEVPKEY_Device_DriverVersion, curInfo->DriverVersion))
 			{
 				dStr << L", " << curInfo->DriverVersion;
 			}
 
+			DEVPROPTYPE PropType;
 			FILETIME fileTime{};
 			SYSTEMTIME sysTime{};
 			if (SetupDiGetDevicePropertyW(
@@ -229,34 +233,19 @@ namespace //private
 				dStr << L"(" << tempStr.data() << L") ";
 			}
 
-			/*
-			if (SetupDiGetDevicePropertyW(
-				m_info,
-				&devInfoData,
-				&DEVPKEY_Device_Service,
-				&PropType,
-				(PBYTE)tempStr.data(),
-				(DWORD)tempStr.size(),
-				&nameSize,
-				0))
+			XI::WString& deviceService = curInfo->DeviceService;
+			if (sdiGetProp(m_info, tempStr, &devInfoData, &DEVPKEY_Device_Service, deviceService))
 			{
-				// With filter as PCI, should never be "SWD" or other indicator of software service
-				dStr << L" service =  \"" << tempStr.data() << L"\"";
+				dStr << L", service = \"" << deviceService << L"\"";
 			}
-			*/
 
-			if (SetupDiGetDevicePropertyW(
-				m_info,
-				&devInfoData,
-				&DEVPKEY_Device_LocationInfo,
-				&PropType,
-				(PBYTE)tempStr.data(),
-				(DWORD)tempStr.size(),
-				&nameSize,
-				0))
+			XI::WString deviceLocation;
+			if ((enumeratorName == L"PCI") && 
+				sdiGetProp(m_info, tempStr, &devInfoData, &DEVPKEY_Device_LocationInfo, deviceLocation)
+				)
 			{
-				dStr << L" at \"" << tempStr.data() << L"\"";
-				bool locValid = curInfo->LocationInfo.GetFromWStr(tempStr.data());
+				dStr << L" at \"" << deviceLocation << L"\"";
+				bool locValid = curInfo->LocationInfo.GetFromWStr(deviceLocation);
 				if (!locValid)
 				{
 					dStr << " ** Error parsing location!\n";
@@ -271,7 +260,7 @@ namespace //private
 			}
 
 			LUID curLUID{};
-			HYBRIDDETECT_DEBUG_REQUIRE(*(UI64*)&curInfo->DeviceLUID == 0ULL);
+			HYBRIDDETECT_DEBUG_REQUIRE(LuidToUI64(curInfo->DeviceLUID) == 0ULL);
 			if (SetupDiGetDevicePropertyW(
 				m_info,
 				&devInfoData,
@@ -283,8 +272,27 @@ namespace //private
 				0) && (nameSize == sizeof(LUID)))
 			{
 				curInfo->DeviceLUID = curLUID;
-				dStr << ", LUID = " << std::hex << *(UI64*)&curLUID << std::dec;
+				XI::UI64 luidUI64 = LuidToUI64(curLUID);
+				dStr << ", LUID = " << std::hex << luidUI64 << std::dec;
+				if (!luidUI64)
+				{
+					dStr << L", SKIPPED\n";
+					continue;
+				}
 			}
+			else
+			{
+				dStr << L", Non-Display, SKIPPED\n";
+				continue;
+			}
+
+#ifdef _DEBUG
+            if (enumeratorName != L"PCI")
+            {
+                dStr << L" ** Device 0x" << std::hex << LuidToUI64(curLUID) << std::dec <<
+                    L" not a PCI device ** (" << enumeratorName << L")" << std::endl;
+            }
+#endif
 
 			outInfos.emplace_back(std::move(curInfo));
 			dStr << std::endl;


### PR DESCRIPTION
### Changes
* XPUInfo/SetupAPI: Filter out adapters that do not originate from PCI devices, removing those from problematic USB port replicators. Skip device on bad port replicator like "HP USB3.0 Port Replicator" or "DisplayLink USB Device".
* DXCore (bug): Gate Device::getMemUsage() so it only calls getMemUsage_DXCORE() when the device is using the DXCore API.
* DXGI: Disable debug layer in debug build, add safety checks
* NVML: Make initialization more robust with added error checking, and now can bypass PCI address matching when both XPUInfo class and NVML indicate one nVidia device. This is an attempt to solve a reported issue that cannot be reproduced.
* CPU: Print microcode revision for Intel CPUs